### PR TITLE
Get Design System 3 page count

### DIFF
--- a/features/support/catalogue_helpers.rb
+++ b/features/support/catalogue_helpers.rb
@@ -5,13 +5,9 @@ module CatalogueHelpers
 
   def self.get_page_count(page)
     begin
-      /\s*(\d+)\s*of\s*(\d+)\s*/.match(page.find(:xpath, "//*[@class='next']//*[@class='page-numbers']").text)[2]
+      /\s*(\d+)\s*of\s*(\d+)\s*/.match(page.find(:xpath, "//*[@class='dm-pagination__link-label']").text)[2]
     rescue Capybara::ElementNotFound
-      begin
-        /\s*(\d+)\s*of\s*(\d+)\s*/.match(page.find(:xpath, "//*[@class='previous']//*[@class='page-numbers']").text)[2]
-      rescue Capybara::ElementNotFound
-        nil
-      end
+      nil
     end
   end
 


### PR DESCRIPTION
The previous xpath worked for the old toolkit, but not for the new Design System 3. We've now switched over all search pages to Design System 3, so don't need to be back-compatible.

The previous behaviour was concealing a bug because the xpath never found anything, so it assumed that there was only one page of results.

I've tested this locally against Preview, and it fails as expected (due to the bug currently exposed on Preview).