### PR TITLE
Use make to install dependencies in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
     - name: Install dependencies
-      run: bundle install
+      run: make install
     - name: Lint Ruby
       run: make lint
     - name: Check features


### PR DESCRIPTION
Running `bundle install` directly skips the config set by `make install`. So it installs the gems to the wrong place, so `make lint` ends up needing to reinstall everything.

See https://github.com/Crown-Commercial-Service/digitalmarketplace-functional-tests/runs/5999990912?check_suite_focus=true for an example of what this should fix.