### PR TITLE
Add a smoulder test to test AWS connection

### DIFF
--- a/features/smoulder-tests/admin/download_supplier_list.feature
+++ b/features/smoulder-tests/admin/download_supplier_list.feature
@@ -1,0 +1,9 @@
+@smoulder-tests
+Feature: Supplier list download
+
+@file-download @skip-local
+Scenario: Framework manager admin can download list of supplier details
+  Given I am logged in as the existing admin-framework-manager user
+  And I click a random link with text 'Contact suppliers'
+  When I click the 'Official details for suppliers' link
+  Then I should get a download file with filename ending '.csv' and content-type 'text/csv'


### PR DESCRIPTION
https://trello.com/c/hsMTMFpi/2445-rotate-aws-access-key

Some apps have AWS credentials to allow them to upload/download from private S3 buckets. It would be useful to have a smoulder test that verifies that the AWS credentials are working correctly. Admin download of supplier details is the only endpoint readily available at all points in the framework lifecycle, so we can use that for our testing.

Should allow us to automate testing of a new AWS access key during rotation.