### PR TITLE
Fix functional tests now project page is back

### DIFF
--- a/features/buyer/buyer_dashboard.feature
+++ b/features/buyer/buyer_dashboard.feature
@@ -1,10 +1,8 @@
 @buyer @buyer-dashboard
 Feature: Buyer Dashboard
 
-# Now that G-Cloud 12 has expired, we cannot procure G-Cloud 12 services
-#
-# Background:
-  # Given I have the latest live g-cloud framework
+Background:
+  Given I have the latest expired 'g-cloud' framework
 
 Scenario: Users should see new Dashboard
   Given I am logged in as a buyer user
@@ -12,13 +10,11 @@ Scenario: Users should see new Dashboard
   Then I see 'Cloud hosting, software and support' text on the page
   And I see 'Digital outcomes, specialists and user research' text on the page
 
-# Now that G-Cloud 12 has expired, we cannot procure G-Cloud 12 services
-#
-# Scenario: Users should see link when there are searches available to view
-  # Given I am logged in as a buyer user
-  # And I have created and saved a search called 'my cloud project'
-  # And I visit the /buyers page
-  # Then I see the 'View your saved searches' link
+Scenario: Users should see link when there are searches available to view
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I visit the /buyers page
+  Then I see the 'View your saved searches' link
 
 Scenario: Users should see message when no searches are created
   Given I am logged in as a buyer user

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -1,11 +1,11 @@
+@buyer @direct-award
+Feature: Direct Award flows
+
+Background:
+  Given I have the latest expired g-cloud framework
+
 # Now that G-Cloud 12 has expired, we cannot procure G-Cloud 12 services
 #
-# @buyer @direct-award
-# Feature: Direct Award flows
-
-# Background:
-#   Given I have the latest live g-cloud framework
-
 # Scenario: Unauthenticated user can save a search after logging in
 #   Given I have an existing buyer user
 #   And I visit the /g-cloud/search page
@@ -58,116 +58,114 @@
 #   And I click 'Save and continue'
 #   Then I am on the 'my cloud project - existing' page
 
-# Scenario: User edits existing search
-#   Given I am logged in as a buyer user
-#   And I have created and saved a search called 'my cloud project'
-#   And I visit the /buyers page
-#   Then I click the 'View your saved searches' link
-#   Then I click the 'my cloud project' link
-#   Then I am on the 'my cloud project' page
-#   And I click the 'Edit your search and view results' link
-#   Then I am on the 'Search results' page
-#   And I click 'Save your search'
-#   Then I am on the 'Save your search' page
-#   And I choose the 'my cloud project' radio button
-#   And I click 'Save and continue'
-#   Then I am on the 'my cloud project' page
+Scenario: User cannot edit existing search
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I visit the /buyers page
+  Then I click the 'View your saved searches' link
+  Then I click the 'my cloud project' link
+  Then I am on the 'my cloud project' page
+  And I cannot see the link 'Edit your search and view results'
 
-# Scenario: User exports results
-#   Given I am logged in as a buyer user
-#   And I have created and saved a search called 'export limit test project'
-#   And I visit the /buyers page
-#   When I click the 'View your saved searches' link
-#   And I click the 'export limit test project' link
-#   Then I am on the 'export limit test project' page
-#   And I see the 'Save a search' instruction list item has a warning message of 'You have too many services to assess. Refine your search until you have no more than 30 results.'
-#   And I see the 'Export your results' instruction list item status showing as 'Cannot start yet'
-#   When I visit the /g-cloud/search?q=cloud+software+nhs&lot=cloud-hosting page
-#   And I click 'Save your search'
-#   Then I am on the 'Save your search' page
-#   And I choose the 'export limit test project' radio button
-#   And I click 'Save and continue'
-#   And I see the 'Save a search' instruction list item status showing as 'Completed'
-#   When I click the 'Export your results' link
-#   Then I am on the 'Before you export your results' page
-#   When I check 'I understand that I cannot edit my search after I export my results' checkbox
-#   And I click the 'Export results and continue' button
-#   Then I am on the 'Download your results' page
-#   And I see a success flash message containing 'Results exported. Your files are ready to download.'
-#   When I click the 'Return to your task list' link
-#   Then I see the 'Export your results' instruction list item status showing as 'Completed'
+Scenario: User cannot export results
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I visit the /buyers page
+  When I click the 'View your saved searches' link
+  And I click the 'my cloud project' link
+  Then I am on the 'my cloud project' page
+  And I cannot see the link 'Edit your search and view results'
+  And the following content should be displayed on the page:
+    | You cannot export these results as the framework you used to create them, G-Cloud 12, has expired. |
+    | You can start a new search for G-Cloud 13 by going to the Contract Award Service.                  |
+  # And I see the 'Save a search' instruction list item has a warning message of 'You have too many services to assess. Refine your search until you have no more than 30 results.'
+  # And I see the 'Export your results' instruction list item status showing as 'Cannot start yet'
+  # When I visit the /g-cloud/search?q=cloud+software+nhs&lot=cloud-hosting page
+  # And I click 'Save your search'
+  # Then I am on the 'Save your search' page
+  # And I choose the 'export limit test project' radio button
+  # And I click 'Save and continue'
+  # And I see the 'Save a search' instruction list item status showing as 'Completed'
+  # When I click the 'Export your results' link
+  # Then I am on the 'Before you export your results' page
+  # When I check 'I understand that I cannot edit my search after I export my results' checkbox
+  # And I click the 'Export results and continue' button
+  # Then I am on the 'Download your results' page
+  # And I see a success flash message containing 'Results exported. Your files are ready to download.'
+  # When I click the 'Return to your task list' link
+  # Then I see the 'Export your results' instruction list item status showing as 'Completed'
 
-# @file-download
-# Scenario: User download results
-#   Given I am logged in as a buyer user
-#   And I have created and saved a search called 'my cloud project'
-#   And I have exported my results for the 'my cloud project' saved search
-#   Then I am on the 'Download your results' page
-#   When I click the 'Download search results as a spreadsheet' link
-#   Then I should get a download file with filename ending '.ods' and content type 'application/vnd.oasis.opendocument.spreadsheet'
-#   When I click the 'Return to your task list' link
-#   Then I am on the 'my cloud project' page
-#   When I click the 'Download your results' link
-#   Then I am on the 'Download your results' page
-#   When I click the 'Download search results as comma-separated values' link
-#   Then I should get a download file with filename ending '.csv' and content type 'text/csv; header=present; charset=utf-8'
+@file-download
+Scenario: User download results
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I have exported my results for the 'my cloud project' saved search
+  Then I am on the 'Download your results' page
+  When I click the 'Download search results as a spreadsheet' link
+  Then I should get a download file with filename ending '.ods' and content type 'application/vnd.oasis.opendocument.spreadsheet'
+  When I click the 'Return to your task list' link
+  Then I am on the 'my cloud project' page
+  When I click the 'Download your results' link
+  Then I am on the 'Download your results' page
+  When I click the 'Download search results as comma-separated values' link
+  Then I should get a download file with filename ending '.csv' and content type 'text/csv; header=present; charset=utf-8'
 
-# @file-download
-# Scenario: User downloads results - via the saved searches dashboard
-#   Given I am logged in as a buyer user
-#   And I am ready to tell the outcome for the 'my cloud project' saved search
-#   When I visit the /buyers/direct-award/g-cloud page
-#   And I click the 'Download results' link
-#   Then I am on the 'Download your results' page
-#   When I click the 'Download search results as a spreadsheet' link
-#   Then I should get a download file with filename ending '.ods' and content type 'application/vnd.oasis.opendocument.spreadsheet'
+@file-download
+Scenario: User downloads results - via the saved searches dashboard
+  Given I am logged in as a buyer user
+  And I am ready to tell the outcome for the 'my cloud project' saved search
+  When I visit the /buyers/direct-award/g-cloud page
+  And I click the 'Download results' link
+  Then I am on the 'Download your results' page
+  When I click the 'Download search results as a spreadsheet' link
+  Then I should get a download file with filename ending '.ods' and content type 'application/vnd.oasis.opendocument.spreadsheet'
 
-# Scenario: User confirms understanding how to assess services
-#   Given I am logged in as a buyer user
-#   And I have created and saved a search called 'my cloud project'
-#   And I have exported my results for the 'my cloud project' saved search
-#   And I click the 'Return to your task list' link
-#   Then I see the 'Export your results' instruction list item status showing as 'Completed'
-#   And I see the 'Award a contract' instruction list item status showing as 'Cannot start yet'
-#   When I click the 'Confirm you have read and understood how to assess services' button
-#   Then I am on the 'my cloud project' page
-#   And I see the 'Start assessing services' instruction list item status showing as 'Completed'
+Scenario: User confirms understanding how to assess services
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I have exported my results for the 'my cloud project' saved search
+  And I click the 'Return to your task list' link
+  Then I see the 'Export your results' instruction list item status showing as 'Completed'
+  And I see the 'Award a contract' instruction list item status showing as 'Cannot start yet'
+  When I click the 'Confirm you have read and understood how to assess services' button
+  Then I am on the 'my cloud project' page
+  And I see the 'Start assessing services' instruction list item status showing as 'Completed'
 
-# Scenario: User awards contract
-#   Given I am logged in as a buyer user
-#   And I am ready to tell the outcome for the 'my cloud project' saved search
-#   When I click the 'Tell us the outcome' link
-#   And I award the contract for the 'my cloud project' search
-#   And I am on the 'my cloud project' page
-#   Then I see a success flash message containing 'You’ve updated ‘my cloud project’'
-#   And I see the 'Award a contract' instruction list item status showing as 'Contract awarded'
+Scenario: User awards contract
+  Given I am logged in as a buyer user
+  And I am ready to tell the outcome for the 'my cloud project' saved search
+  When I click the 'Tell us the outcome' link
+  And I award the contract for the 'my cloud project' search
+  And I am on the 'my cloud project' page
+  Then I see a success flash message containing 'You’ve updated ‘my cloud project’'
+  And I see the 'Award a contract' instruction list item status showing as 'Contract awarded'
 
-# Scenario: User does not award contract as work is cancelled
-#   Given I am logged in as a buyer user
-#   And I am ready to tell the outcome for the 'my cloud project' saved search
-#   When I click the 'Tell us the outcome' link
-#   And I do not award the contract because 'The work has been cancelled'
-#   And I am on the 'my cloud project' page
-#   Then I see a success flash message containing 'You’ve updated ‘my cloud project’'
-#   And I see the 'Award a contract' instruction list item status showing as 'The work has been cancelled'
+Scenario: User does not award contract as work is cancelled
+  Given I am logged in as a buyer user
+  And I am ready to tell the outcome for the 'my cloud project' saved search
+  When I click the 'Tell us the outcome' link
+  And I do not award the contract because 'The work has been cancelled'
+  And I am on the 'my cloud project' page
+  Then I see a success flash message containing 'You’ve updated ‘my cloud project’'
+  And I see the 'Award a contract' instruction list item status showing as 'The work has been cancelled'
 
-# Scenario: User does not award contract as there are no suitable services
-#   Given I am logged in as a buyer user
-#   And I am ready to tell the outcome for the 'my cloud project' saved search
-#   When I click the 'Tell us the outcome' link
-#   And I do not award the contract because 'There were no suitable services'
-#   And I am on the 'my cloud project' page
-#   Then I see a success flash message containing 'You’ve updated ‘my cloud project’'
-#   And I see the 'Award a contract' instruction list item status showing as 'No suitable services found'
+Scenario: User does not award contract as there are no suitable services
+  Given I am logged in as a buyer user
+  And I am ready to tell the outcome for the 'my cloud project' saved search
+  When I click the 'Tell us the outcome' link
+  And I do not award the contract because 'There were no suitable services'
+  And I am on the 'my cloud project' page
+  Then I see a success flash message containing 'You’ve updated ‘my cloud project’'
+  And I see the 'Award a contract' instruction list item status showing as 'No suitable services found'
 
-# @file-download
-# Scenario: User is still assessing services - via the saved searches dashboard
-#   Given I am logged in as a buyer user
-#   And I am ready to tell the outcome for the 'my cloud project' saved search
-#   And I have downloaded the search results as a file of type 'csv'
-#   When I visit the /buyers/direct-award/g-cloud page
-#   When I click the 'Tell us the outcome' link
-#   And I choose the 'We are still assessing services' radio button
-#   And I click 'Save and continue'
-#   And I am on the 'my cloud project' page
-#   Then I see the 'Tell us the outcome' link
+@file-download
+Scenario: User is still assessing services - via the saved searches dashboard
+  Given I am logged in as a buyer user
+  And I am ready to tell the outcome for the 'my cloud project' saved search
+  And I have downloaded the search results as a file of type 'csv'
+  When I visit the /buyers/direct-award/g-cloud page
+  When I click the 'Tell us the outcome' link
+  And I choose the 'We are still assessing services' radio button
+  And I click 'Save and continue'
+  And I am on the 'my cloud project' page
+  Then I see the 'Tell us the outcome' link

--- a/features/smoke-tests/homepage.feature
+++ b/features/smoke-tests/homepage.feature
@@ -3,7 +3,7 @@ Feature: Check appropriate links on homepage
 
 Scenario: User can see the main links on the homepage
   Given I visit the homepage
-  Then I see the 'Find cloud hosting, software and support' link
+  # Then I see the 'Find cloud hosting, software and support' link
   And I see the 'Find physical datacentre space' link
   And I see the 'Find an individual specialist' link
   And I see the 'Find a team to provide an outcome' link

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -24,13 +24,13 @@ When (/^I am ready to tell the outcome for the '(.*)' saved search$/) do |search
 end
 
 When (/^I have exported my results for the '(.*)' saved search$/) do |search_name|
+  export_direct_award_project
+
   steps %{
     Given I visit the /buyers/direct-award/g-cloud page
     And I click the '#{search_name}' link
-    And I click the 'Export your results' link
-    And I check 'I understand that I cannot edit my search after I export my results' checkbox
-    And I click the 'Export results and continue' button
-    Then I see a success flash message containing 'Results exported. Your files are ready to download.'
+    And I am on the '#{search_name}' page
+    And I click the 'Download your results' link
   }
 end
 

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -711,3 +711,15 @@ def create_direct_award_project(user, project_name, search_query)
 
   project
 end
+
+def export_direct_award_project
+  response = call_api(
+    :post,
+    "/direct-award/projects/#{@project['id']}/lock",
+    payload: {
+      "updated_by": "functional tests"
+    }
+  )
+
+  expect(response.code).to eq(200), response
+end


### PR DESCRIPTION
Now that the projects page has been fixed for when G-Cloud 12 has expired, we can re-add some of the tests that were removed