### PR TITLE
Remove tests that require live DOS briefs

### DIFF
--- a/features/buyer/buyer_clarification.feature
+++ b/features/buyer/buyer_clarification.feature
@@ -1,19 +1,20 @@
-@buyer @buyer-clarification
-Feature: Buyer publishes question and answer
+# As DOS5 is closed, buyers will be unable to create new requirements so we need to remove these tests
+# @buyer @buyer-clarification
+# Feature: Buyer publishes question and answer
 
-Scenario: Buyer publishes answers to clarification questions on a brief which the public can see
-  Given I am logged in as the buyer of a live brief
-  And I go to that brief overview page
+# Scenario: Buyer publishes answers to clarification questions on a brief which the public can see
+#   Given I am logged in as the buyer of a live brief
+#   And I go to that brief overview page
 
-  When I click the 'Publish questions and answers' link
-  Then I am on the 'Supplier questions' page
+#   When I click the 'Publish questions and answers' link
+#   Then I am on the 'Supplier questions' page
 
-  When I click the 'Answer a supplier question' link
-  Then I am on the 'Publish questions and answers' page
+#   When I click the 'Answer a supplier question' link
+#   Then I am on the 'Publish questions and answers' page
 
-  When I publish an answer to a question
-  Then I am on the 'Supplier questions' page
+#   When I publish an answer to a question
+#   Then I am on the 'Supplier questions' page
 
-  When I click the 'Log out'
-  And I go to that brief page
-  Then I see the published question and answer
+#   When I click the 'Log out'
+#   And I go to that brief page
+#   Then I see the published question and answer

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -220,34 +220,35 @@ Feature: Create and publish a requirement
 #   And I click 'Cancel'
 #   Then I am on that brief overview page
 
+# As DOS5 is closed, buyers will be unable to create new requirements so we need to remove these tests
+# as they wont be able to make use of a live brief
+# Scenario: Withdraw live requirements
+#   Given I am logged in as the buyer of a live brief
 
-Scenario: Withdraw live requirements
-  Given I am logged in as the buyer of a live brief
+#   When I click the 'View your account' link
+#   And I click the 'View your requirements' link
+#   Then I see that the 'Published requirements' summary table has 1 or more entries
 
-  When I click the 'View your account' link
-  And I click the 'View your requirements' link
-  Then I see that the 'Published requirements' summary table has 1 or more entries
-
-  When I go to that brief overview page
-  Then I see the 'Withdraw requirements' link
-  And I click 'Withdraw requirements'
-  Then I am on the 'Are you sure you want to withdraw these requirements?' page
-  Then I see the 'Withdraw requirements' button
-  And I click 'Withdraw requirements'
-  Then I am on the 'Your requirements' page
-  Then I see a success flash message containing 'withdrawn your requirements'
+#   When I go to that brief overview page
+#   Then I see the 'Withdraw requirements' link
+#   And I click 'Withdraw requirements'
+#   Then I am on the 'Are you sure you want to withdraw these requirements?' page
+#   Then I see the 'Withdraw requirements' button
+#   And I click 'Withdraw requirements'
+#   Then I am on the 'Your requirements' page
+#   Then I see a success flash message containing 'withdrawn your requirements'
 
 
-Scenario: Cancel a withdraw draft requirement request
-  Given I am logged in as the buyer of a live brief
-  And I go to that brief overview page
+# Scenario: Cancel a withdraw draft requirement request
+#   Given I am logged in as the buyer of a live brief
+#   And I go to that brief overview page
   
-  Then I see the 'Withdraw requirements' link
-  And I click 'Withdraw requirements'
-  Then I am on the 'Are you sure you want to withdraw these requirements?' page
-  Then I see the 'Cancel' link
-  And I click 'Cancel'
-  Then I am on that brief overview page
+#   Then I see the 'Withdraw requirements' link
+#   And I click 'Withdraw requirements'
+#   Then I am on the 'Are you sure you want to withdraw these requirements?' page
+#   Then I see the 'Cancel' link
+#   And I click 'Cancel'
+#   Then I am on that brief overview page
 
 
 # As DOS5 is closed, buyers will be unable to publish new requirements so will be unable to edit ones that have already been created


### PR DESCRIPTION
As DOS 5 is closing, there are no new DOS 5 briefs being created so these tests do not have the data they need to work.